### PR TITLE
Multi model support

### DIFF
--- a/src/common/camera-delegate/camera_delegate.cpp
+++ b/src/common/camera-delegate/camera_delegate.cpp
@@ -1,0 +1,368 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#include "camera_delegate.h"
+#include <rs/playback/playback_context.h>
+#include <string>
+#include <vector>
+
+static const size_t MAX_USB_DEVICES = 256;
+
+/////////////////////////////////////////////////////////////////////////////
+
+class CameraDelegateDeviceD {
+ public:
+  friend class CameraDelegate;
+  friend class CameraDelegateDevice;
+
+  CameraDelegateDeviceD() {
+    device = nullptr;
+    streaming_counter = 0;
+    motion_handler_set = false;
+  }
+
+  rs::device* device;  // No need to delete this pointer
+  int streaming_counter;
+
+  typedef std::function<void(rs::motion_data)> motion_handler_t;
+  typedef std::function<void(rs::timestamp_data)> timestamp_handler_t;
+
+  std::vector<motion_handler_t> motion_handlers;
+  std::vector<timestamp_handler_t> timestamp_handlers;
+
+  bool motion_handler_set;
+};
+
+/////////////////////////////////////////////////////////////////////////////
+
+class CameraDelegateD {
+  CameraDelegateD() {
+    context = nullptr;
+    device_delegate.reserve(MAX_USB_DEVICES);  // Ensures no memory re-alloc
+    device_delegate.resize(0);
+  }
+
+  friend class CameraDelegate;
+  rs::core::context_interface* context;
+  std::vector<CameraDelegateDeviceD> device_delegate;
+  std::string playback_filename;
+
+  void ResetContext() {
+    delete context;
+    context = nullptr;
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////
+CameraDelegate::CameraDelegate() {
+  d_ = new CameraDelegateD();
+  ConnectToRealCamera();
+}
+
+CameraDelegate::~CameraDelegate() {
+  d_->ResetContext();
+  delete d_;
+}
+
+void CameraDelegate::ConnectToVirtualCamera(const std::string& fileName) {
+  d_->ResetContext();
+  d_->context = new rs::playback::context(fileName.c_str());
+  d_->playback_filename = fileName;
+  for (size_t i = 0 ; i < d_->device_delegate.size() ; ++i) {
+    d_->device_delegate[i].device = d_->context->get_device(i);
+  }
+}
+
+void CameraDelegate::ConnectToRealCamera() {
+  d_->ResetContext();
+  d_->context = new rs::core::context();
+  for (size_t i = 0 ; i < d_->device_delegate.size() ; ++i) {
+    d_->device_delegate[i].device = d_->context->get_device(i);
+  }
+  d_->playback_filename = "";
+}
+
+bool CameraDelegate::IsVirtualCamera() const {
+  return d_->playback_filename.length() > 0;
+}
+
+const std::string& CameraDelegate::GetVirtualCameraFileName() const {
+  return d_->playback_filename;
+}
+
+int CameraDelegate::get_device_count() const {
+  return d_->context->get_device_count();
+}
+
+CameraDelegateDevice* CameraDelegate::get_device(int index) {
+  const size_t idx = index;
+  if (idx >= MAX_USB_DEVICES) {
+    return nullptr;
+  }
+  if (idx >= d_->device_delegate.size()) {
+    d_->device_delegate.resize(idx + 1);
+  }
+  d_->device_delegate[idx].device = d_->context->get_device(index);
+  return new CameraDelegateDevice(d_->device_delegate.data() + idx);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+CameraDelegateDevice::CameraDelegateDevice(CameraDelegateDeviceD* d) {
+  d_ = d;
+}
+
+CameraDelegateDevice::~CameraDelegateDevice() {
+}
+
+rs::device* CameraDelegateDevice::get_device() {
+  return d_->device;
+}
+
+const char* CameraDelegateDevice::get_name() const {
+  return d_->device->get_name();
+}
+
+const char* CameraDelegateDevice::get_serial() const {
+  return d_->device->get_serial();
+}
+
+const char* CameraDelegateDevice::get_usb_port_id() const {
+  return d_->device->get_usb_port_id();
+}
+
+const char* CameraDelegateDevice::get_firmware_version() const {
+  return d_->device->get_firmware_version();
+}
+
+const char* CameraDelegateDevice::get_info(rs::camera_info info) const {
+  return d_->device->get_info(info);
+}
+
+rs::extrinsics CameraDelegateDevice::get_extrinsics(rs::stream from_stream,
+    rs::stream to_stream) const {
+  return d_->device->get_extrinsics(from_stream, to_stream);
+}
+
+rs::extrinsics CameraDelegateDevice::get_motion_extrinsics_from(
+    rs::stream from_stream) const {
+  return d_->device->get_motion_extrinsics_from(from_stream);
+}
+
+float CameraDelegateDevice::get_depth_scale() const {
+  return d_->device->get_depth_scale();
+}
+
+bool CameraDelegateDevice::supports_option(rs::option option) const {
+  return d_->device->supports_option(option);
+}
+
+int CameraDelegateDevice::get_stream_mode_count(rs::stream stream) const {
+  return d_->device->get_stream_mode_count(stream);
+}
+
+void CameraDelegateDevice::get_stream_mode(rs::stream stream, int index,
+    int& width, int& height, rs::format & format, int & framerate) const {
+  return d_->device->get_stream_mode(stream, index, width, height,
+    format, framerate);
+}
+
+void CameraDelegateDevice::enable_stream(rs::stream stream,
+    int width, int height, rs::format format, int framerate,
+    rs::output_buffer_format output_buffer_type) {
+  if (!is_streaming()) {
+    // Only when camera is not working
+    return d_->device->enable_stream(stream, width, height,
+        format, framerate, output_buffer_type);
+  }
+}
+
+void CameraDelegateDevice::enable_stream(rs::stream stream,
+    rs::preset preset) {
+  if (!is_streaming()) {
+    // Only when camera is not working
+    return d_->device->enable_stream(stream, preset);
+  }
+}
+
+void CameraDelegateDevice::disable_stream(rs::stream stream) {
+  if (!is_streaming()) {
+    // Only when camera is not working
+    return d_->device->disable_stream(stream);
+  }
+}
+
+bool CameraDelegateDevice::is_stream_enabled(rs::stream stream) const {
+  return d_->device->is_stream_enabled(stream);
+}
+
+int CameraDelegateDevice::get_stream_width(rs::stream stream) const {
+  return d_->device->get_stream_width(stream);
+}
+
+int CameraDelegateDevice::get_stream_height(rs::stream stream) const {
+  return d_->device->get_stream_height(stream);
+}
+
+rs::format CameraDelegateDevice::get_stream_format(rs::stream stream) const {
+  return d_->device->get_stream_format(stream);
+}
+
+int CameraDelegateDevice::get_stream_framerate(rs::stream stream) const {
+  return d_->device->get_stream_framerate(stream);
+}
+
+rs::intrinsics CameraDelegateDevice::get_stream_intrinsics(
+    rs::stream stream) const {
+  return d_->device->get_stream_intrinsics(stream);
+}
+
+rs::motion_intrinsics CameraDelegateDevice::get_motion_intrinsics() const {
+  return d_->device->get_motion_intrinsics();
+}
+
+void CameraDelegateDevice::set_frame_callback(rs::stream stream,
+    std::function<void(rs::frame)> frame_handler) {
+  return d_->device->set_frame_callback(stream, frame_handler);
+}
+
+void CameraDelegateDevice::enable_motion_tracking(
+    std::function<void(rs::motion_data)> motion_handler,
+    std::function<void(rs::timestamp_data)> timestamp_handler) {
+  if (!d_->motion_handler_set) {
+    d_->device->enable_motion_tracking([this](rs::motion_data data){
+      for (auto i = this->d_->motion_handlers.begin();
+        i != this->d_->motion_handlers.end();
+        ++i) {
+        i->operator () (data);
+      }
+    }, [this](rs::timestamp_data data){
+      for (auto i = this->d_->timestamp_handlers.begin();
+        i != this->d_->timestamp_handlers.end();
+        ++i) {
+        i->operator () (data);
+      }
+    });
+    d_->motion_handler_set = true;
+  }
+
+  d_->motion_handlers.push_back(motion_handler);
+  d_->timestamp_handlers.push_back(timestamp_handler);
+}
+
+void CameraDelegateDevice::enable_motion_tracking(
+    std::function<void(rs::motion_data)> motion_handler) {
+  if (!d_->motion_handler_set) {
+    d_->device->enable_motion_tracking([this](rs::motion_data data){
+      for (auto i = this->d_->motion_handlers.begin();
+        i != this->d_->motion_handlers.end();
+        ++i) {
+        i->operator () (data);
+      }
+    });
+    d_->motion_handler_set = true;
+  }
+
+  d_->motion_handlers.push_back(motion_handler);
+}
+
+void CameraDelegateDevice::disable_motion_tracking(void) {
+  d_->motion_handler_set = false;
+  d_->motion_handlers.resize(0);
+  d_->timestamp_handlers.resize(0);
+
+  return d_->device->disable_motion_tracking();
+}
+
+int CameraDelegateDevice::is_motion_tracking_active() {
+  return d_->device->is_motion_tracking_active();
+}
+
+void CameraDelegateDevice::start(rs::source source) {
+  ++d_->streaming_counter;
+  if (!is_streaming()) {
+    // Only call through for the first time
+    d_->device->start(source);
+  }
+}
+
+void CameraDelegateDevice::stop(rs::source source) {
+  --d_->streaming_counter;
+
+  if (d_->streaming_counter <= 0) {
+    d_->streaming_counter = 0;
+    // It's time to stop it for real
+    return d_->device->stop(source);
+  }
+}
+
+bool CameraDelegateDevice::is_streaming() const {
+  return d_->device->is_streaming();
+}
+
+void CameraDelegateDevice::get_option_range(rs::option option,
+    double & min, double & max, double & step) {
+  return d_->device->get_option_range(option, min, max, step);
+}
+
+void CameraDelegateDevice::get_option_range(rs::option option,
+    double & min, double & max, double & step, double & def) {
+  return d_->device->get_option_range(option, min, max, step, def);
+}
+
+void CameraDelegateDevice::get_options(const rs::option* options,
+    size_t count, double * values) {
+  return d_->device->get_options(options, count, values);
+}
+
+void CameraDelegateDevice::set_options(const rs::option* options,
+    size_t count, const double * values) {
+  return d_->device->set_options(options, count, values);
+}
+
+double CameraDelegateDevice::get_option(rs::option option) {
+  return d_->device->get_option(option);
+}
+
+const char* CameraDelegateDevice::get_option_description(rs::option option) {
+  return d_->device->get_option_description(option);
+}
+
+void CameraDelegateDevice::set_option(rs::option option, double value) {
+  return d_->device->set_option(option, value);
+}
+
+void CameraDelegateDevice::wait_for_frames() {
+  return d_->device->wait_for_frames();
+}
+
+bool CameraDelegateDevice::poll_for_frames() {
+  return d_->device->poll_for_frames();
+}
+
+bool CameraDelegateDevice::supports(rs::capabilities capability) const {
+  return d_->device->supports(capability);
+}
+
+bool CameraDelegateDevice::supports(rs::camera_info info_param) const {
+  return d_->device->supports(info_param);
+}
+
+double CameraDelegateDevice::get_frame_timestamp(rs::stream stream) const {
+  return d_->device->get_frame_timestamp(stream);
+}
+
+unsigned long long CameraDelegateDevice::get_frame_number(  // NOLINT(*)
+    rs::stream stream) const {
+  return d_->device->get_frame_number(stream);
+}
+
+const void* CameraDelegateDevice::get_frame_data(rs::stream stream) const {
+  return d_->device->get_frame_data(stream);
+}
+
+void CameraDelegateDevice::send_blob_to_device(rs::blob_type type,
+    void * data, int size) {
+  return d_->device->send_blob_to_device(type, data, size);
+}

--- a/src/common/camera-delegate/camera_delegate.h
+++ b/src/common/camera-delegate/camera_delegate.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#ifndef _CAMERA_DELEGATE_H_
+#define _CAMERA_DELEGATE_H_
+
+#include <librealsense/rs.hpp>
+#include <string>
+
+class CameraDelegateDevice {
+  CameraDelegateDevice(const CameraDelegateDevice&) = delete;
+  CameraDelegateDevice& operator = (const CameraDelegateDevice&) = delete;
+
+ public:
+  explicit CameraDelegateDevice(class CameraDelegateDeviceD*);
+  ~CameraDelegateDevice();
+
+ public:
+  rs::device* get_device();
+
+  const char * get_name() const;
+  const char * get_serial() const;
+  const char * get_usb_port_id() const;
+  const char * get_firmware_version() const;
+  const char * get_info(rs::camera_info info) const;
+  rs::extrinsics get_extrinsics(rs::stream from_stream,
+      rs::stream to_stream) const;
+  rs::extrinsics get_motion_extrinsics_from(rs::stream from_stream) const;
+  float get_depth_scale() const;
+  bool supports_option(rs::option option) const;
+  int get_stream_mode_count(rs::stream stream) const;
+  void get_stream_mode(rs::stream stream, int index,
+      int & width, int & height, rs::format & format, int & framerate) const;  // NOLINT(*)
+  void enable_stream(rs::stream stream, int width, int height,
+      rs::format format, int framerate,
+      rs::output_buffer_format output_buffer_type
+      = rs::output_buffer_format::continous);
+  void enable_stream(rs::stream stream, rs::preset preset);
+  void disable_stream(rs::stream stream);
+  bool is_stream_enabled(rs::stream stream) const;
+  int get_stream_width(rs::stream stream) const;
+  int get_stream_height(rs::stream stream) const;
+  rs::format get_stream_format(rs::stream stream) const;
+  int get_stream_framerate(rs::stream stream) const;
+  rs::intrinsics get_stream_intrinsics(rs::stream stream) const;
+  rs::motion_intrinsics get_motion_intrinsics() const;
+  void set_frame_callback(
+      rs::stream stream, std::function<void(rs::frame)> frame_handler);
+  void enable_motion_tracking(
+      std::function<void(rs::motion_data)> motion_handler,
+      std::function<void(rs::timestamp_data)> timestamp_handler);
+  void enable_motion_tracking(
+      std::function<void(rs::motion_data)> motion_handler);
+  void disable_motion_tracking(void);
+  int is_motion_tracking_active();
+  void start(rs::source source = rs::source::video);
+  void stop(rs::source source = rs::source::video);
+  bool is_streaming() const;
+  void get_option_range(rs::option option,
+      double & min, double & max, double & step);  // NOLINT(*)
+  void get_option_range(rs::option option,
+      double & min, double & max, double & step, double & def);  // NOLINT(*)
+  void get_options(const rs::option* options,
+      size_t count, double * values);
+  void set_options(const rs::option* options,
+      size_t count, const double * values);
+  double get_option(rs::option option);
+  const char * get_option_description(rs::option option);
+  void set_option(rs::option option, double value);
+  void wait_for_frames();
+  bool poll_for_frames();
+  bool supports(rs::capabilities capability) const;
+  bool supports(rs::camera_info info_param) const;
+  double get_frame_timestamp(rs::stream stream) const;
+  unsigned long long get_frame_number(rs::stream stream) const;    // NOLINT(*)
+  const void * get_frame_data(rs::stream stream) const;
+  void send_blob_to_device(rs::blob_type type, void * data, int size);
+
+ private:
+  class CameraDelegateDeviceD * d_;
+};
+
+class CameraDelegate {
+  CameraDelegate(const CameraDelegate&) = delete;
+  CameraDelegate& operator = (const CameraDelegate&) = delete;
+
+ public:
+  CameraDelegate();
+  ~CameraDelegate();
+
+  void ConnectToVirtualCamera(const std::string& fileName);
+  void ConnectToRealCamera();
+  bool IsVirtualCamera() const;
+  const std::string& GetVirtualCameraFileName() const;
+
+ public:
+  int get_device_count() const;
+  CameraDelegateDevice* get_device(int index);
+
+ private:
+  class CameraDelegateD * d_;
+};
+
+#endif  // _CAMERA_DELEGATE_H_

--- a/src/common/camera-delegate/camera_delegate_instance.cpp
+++ b/src/common/camera-delegate/camera_delegate_instance.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#include "camera_delegate_instance.h"
+#include "../process-singleton/process_singleton.h"
+
+struct CameraDelegateTraits {
+  static constexpr const char* shm_name = "node-realsense-shm-camera-delegate:";
+};
+
+typedef ProcessSingleton<CameraDelegate,
+    CameraDelegateTraits> camera_delegate_singleton_t;
+
+static const int required_dummy =
+    camera_delegate_singleton_t::SetupCleanupHooks();
+
+class CameraDelegateInstanceD {
+  friend class CameraDelegateInstance;
+
+  static void DestroyInstance() {
+    camera_delegate_singleton_t::Cleanup();
+    delete instance_;
+    instance_ = nullptr;
+  }
+
+  static CameraDelegate* GetInstance() {
+    if (!instance_) {
+      if (!camera_delegate_singleton_t::QueryExistence()) {
+        // Create one instance per one single OS process
+        try {
+          camera_delegate_singleton_t::SetInstance(new CameraDelegate());
+        } catch (const boost::interprocess::interprocess_exception& e) {
+          // Just absort it and do nothing
+        }
+      }
+      instance_ = camera_delegate_singleton_t::GetInstance();
+    }
+
+    return instance_;
+  }
+
+  static CameraDelegate* instance_;
+};
+
+CameraDelegate* CameraDelegateInstanceD::instance_ = nullptr;
+
+CameraDelegate* CameraDelegateInstance::GetInstance() {
+  return CameraDelegateInstanceD::GetInstance();
+}

--- a/src/common/camera-delegate/camera_delegate_instance.h
+++ b/src/common/camera-delegate/camera_delegate_instance.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#ifndef _CAMERA_DELEGATE_INSTANCE_H_
+#define _CAMERA_DELEGATE_INSTANCE_H_
+
+#include "camera_delegate.h"
+
+class CameraDelegateInstance {
+  CameraDelegateInstance() = delete;
+  ~CameraDelegateInstance() = delete;
+
+ public:
+  static CameraDelegate* GetInstance();
+  static void DestroyInstance();
+};
+
+#endif  // _CAMERA_DELEGATE_INSTANCE_H_

--- a/src/common/camera-options/camera_options_coprocessor.h
+++ b/src/common/camera-options/camera_options_coprocessor.h
@@ -1,0 +1,114 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#include <librealsense/rs.hpp>
+
+#include "common/camera-options/camera_options_type.h"
+
+class CameraOptionsCoProcessor {
+ public:
+  enum Caller {
+    ObjectRecognition,
+    PersonTracking,
+    SLAM
+  };
+
+  CameraOptionsCoProcessor(const CameraOptionsType& cameraOptions,
+      Caller caller) {
+    expected_camera_config_ = cameraOptions;
+    caller_ = caller;
+
+    const auto& expected = expected_camera_config_;
+    if (expected.has_member_fisheye) {
+      const auto& fisheye =  expected.member_fisheye;
+      if (fisheye.has_member_isEnabled && fisheye.member_isEnabled) {
+        // Yes, we're probably working with SLAM add-on
+        fisheye_request_ = true;
+      }
+    }
+
+    if (expected.has_member_color) {
+      const auto& color =  expected.member_color;
+      if (color.has_member_isEnabled && color.member_isEnabled) {
+        // Yes, we're probably working with SLAM add-on
+        color_request_ = true;
+      }
+    }
+  }
+
+  void TryEnableExtraChannels(CameraDelegateDevice* device) {
+    if (caller_ == Caller::SLAM) {
+      if (color_request_) {
+        try {
+          const auto& color = expected_camera_config_.member_color;
+          device->enable_stream(rs::stream::color,
+            color.member_width,
+            color.member_height,
+            rs::format::rgb8,
+            color.member_frameRate);
+        } catch(...) {
+          // Absort all exceptions
+        }
+      }
+    } else {
+      if (fisheye_request_ && device->supports(rs::capabilities::fish_eye)) {
+        try {
+          const auto& fisheye = expected_camera_config_.member_fisheye;
+          device->enable_stream(rs::stream::fisheye,
+            fisheye.member_width,
+            fisheye.member_height,
+            rs::format::raw8,
+            fisheye.member_frameRate);
+        } catch(...) {
+          // Absort all exceptions
+        }
+      }
+    }
+  }
+
+  void TrySetExtraOptions(CameraDelegateDevice* device) {
+    if (caller_ == Caller::SLAM) {
+      if (color_request_) {
+        // Working with PT/OR add-on
+        device->set_option(rs::option::color_enable_auto_exposure, 1);
+      }
+    } else {
+      if (fisheye_request_) {
+        if (device->supports(rs::capabilities::fish_eye)) {
+          device->set_option(rs::option::fisheye_strobe, 1);
+          device->set_option(rs::option::fisheye_color_auto_exposure, 1);
+        }
+
+        if (device->supports(rs::capabilities::motion_events)) {
+          // CameraDelegateDevice will maintain an internal list of callbacks
+          device->enable_motion_tracking([](rs::motion_data){
+            // NOP
+          }, [](rs::timestamp_data){
+            // NOP
+          });
+        }
+      }
+    }
+  }
+
+  rs::source GetCameraStartOptions(CameraDelegateDevice* device) const {
+    if (caller_ == Caller::SLAM) {
+      return rs::source::all_sources;
+    } else {
+      if (fisheye_request_) {
+        if (device->supports(rs::capabilities::motion_events)) {
+          // Only in this case we consider request for SLAM addon
+          return rs::source::all_sources;
+        }
+      }
+    }
+    return rs::source::video;
+  }
+
+ private:
+  CameraOptionsType expected_camera_config_;
+  Caller caller_;
+  bool   fisheye_request_;
+  bool   color_request_;
+};

--- a/src/common/camera-options/camera_options_host.cpp
+++ b/src/common/camera-options/camera_options_host.cpp
@@ -31,6 +31,17 @@ class CameraOptionsHostD {
     color_stream.member_height = 480;
     color_stream.member_frameRate = 30;
 
+    camera_options_.has_member_fisheye = true;
+    auto& fisheye_stream = camera_options_.member_fisheye;
+    fisheye_stream.has_member_width = true;
+    fisheye_stream.has_member_height = true;
+    fisheye_stream.has_member_frameRate = true;
+    fisheye_stream.has_member_isEnabled = true;
+    fisheye_stream.member_isEnabled = true;
+    fisheye_stream.member_width = 640;
+    fisheye_stream.member_height = 480;
+    fisheye_stream.member_frameRate = 30;
+
     camera_options_.has_member_depth = true;
     auto& depth_stream = camera_options_.member_depth;
     depth_stream.has_member_width = true;

--- a/src/common/camera-options/camera_options_host_instance.cpp
+++ b/src/common/camera-options/camera_options_host_instance.cpp
@@ -3,17 +3,34 @@
 // found in the LICENSE file.
 
 #include "camera_options_host_instance.h"
+#include "../process-singleton/process_singleton.h"
+
+struct CameraOptionsHostTraits {
+  static constexpr const char* shm_name = "node-realsense-shm-camera-options:";
+};
+
+typedef ProcessSingleton<CameraOptionsHost,
+    CameraOptionsHostTraits> options_host_singleton_t;
+
+static const int required_dummy =
+    options_host_singleton_t::SetupCleanupHooks();
 
 class CameraOptionsHostInstanceD {
   friend class CameraOptionsHostInstance;
 
   static void DestroyInstance() {
+    options_host_singleton_t::Cleanup();
     delete instance_;
+    instance_ = nullptr;
   }
 
   static CameraOptionsHost* GetInstance() {
     if (!instance_) {
-      instance_ = new CameraOptionsHost();
+      if (!options_host_singleton_t::QueryExistence()) {
+        // Create one instance per one single OS process
+        options_host_singleton_t::SetInstance(new CameraOptionsHost());
+      }
+      instance_ = options_host_singleton_t::GetInstance();
     }
 
     return instance_;

--- a/src/common/camera-options/camera_options_host_instance.h
+++ b/src/common/camera-options/camera_options_host_instance.h
@@ -7,10 +7,6 @@
 
 #include "camera_options_host.h"
 
-//
-// TODO(Kenny): to share the same instance across different add-ons (*.so)
-//              maybe: shm_open("<unique_name>+<pid>")
-//
 class CameraOptionsHostInstance {
   CameraOptionsHostInstance();
   ~CameraOptionsHostInstance();

--- a/src/common/process-singleton/process_singleton.h
+++ b/src/common/process-singleton/process_singleton.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#ifndef _PROCESS_SINGLETON_H_
+#define _PROCESS_SINGLETON_H_
+
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+#include <string>
+#include <sstream>
+
+using namespace boost::interprocess; // NOLINT(*)
+
+template <class T, class TraitsT>
+class ProcessSingleton {
+  ProcessSingleton() = delete;
+  ~ProcessSingleton() = delete;
+
+ public:
+  static bool QueryExistence() {
+    try {
+      shared_memory_object shared_mem(open_only,
+          GetName().c_str(),
+          read_write);
+      return true;
+    } catch (const boost::interprocess::interprocess_exception& e) {
+    }
+    return false;
+  }
+
+  static void SetInstance(T* ptr) {
+    if (!hooks_set_) {
+      // Force client to set hooks
+      throw "Invoke SetupCleanupHooks() first";
+    }
+
+    shared_memory_object shared_mem(create_only,
+        GetName().c_str(),
+        read_write);
+    shared_mem.truncate(shared_mem_size_);
+    mapped_region region(shared_mem, read_write, 0, shared_mem_size_);
+    void* shm = region.get_address();
+
+    memcpy(shm, &ptr, sizeof(ptr));
+  }
+
+  static T* GetInstance() {
+    shared_memory_object shared_mem(open_only,
+        GetName().c_str(),
+        read_write);
+    shared_mem.truncate(shared_mem_size_);
+    mapped_region region(shared_mem, read_write, 0, shared_mem_size_);
+    void* shm = region.get_address();
+
+    void* result = nullptr;
+    memcpy(&result, shm, sizeof(result));
+    return static_cast<T*>(result);
+  }
+
+  static void Cleanup() {
+    shared_memory_object::remove(GetName().c_str());
+  }
+
+  static int SetupCleanupHooks() {
+    hooks_set_ = true;
+
+    static std::terminate_handler prev_t {std::set_terminate([]() {
+      Cleanup();
+      if (prev_t) {
+        prev_t();
+      }
+      std::abort();
+    })};
+
+    atexit([]() {
+      Cleanup();
+    });
+
+    std::set_unexpected([](){
+      Cleanup();
+      std::terminate();
+    });
+
+    return 1;
+  }
+
+  static void TestException() {
+    throw "this goes to coredump";
+  }
+
+ private:
+  static std::string GetName() {
+    std::stringstream ss;
+    ss << TraitsT::shm_name << getpid();
+    return ss.str();
+  }
+
+  static const size_t shared_mem_size_ = sizeof (T*);
+  static bool hooks_set_;
+};
+
+template <class T, class TraitsT>
+bool ProcessSingleton<T, TraitsT>::hooks_set_ = false;
+
+
+#endif  // _PROCESS_SINGLETON_H_

--- a/src/common/task/async_task_runner_instance.h
+++ b/src/common/task/async_task_runner_instance.h
@@ -7,10 +7,6 @@
 
 #include "async_task_runner.h"
 
-//
-// TODO(Kenny): make this a seperate *.so
-// to share the same instance across different add-on(s)
-//
 class AsyncTaskRunnerInstance {
   AsyncTaskRunnerInstance();
   ~AsyncTaskRunnerInstance();

--- a/src/object-recognition/binding.gyp
+++ b/src/object-recognition/binding.gyp
@@ -38,6 +38,8 @@
       ],
       "sources": [
         "addon.cpp",
+        "common/camera-delegate/camera_delegate.cpp",
+        "common/camera-delegate/camera_delegate_instance.cpp",
         "common/camera-options/camera_options_host.cpp",
         "common/camera-options/camera_options_host_instance.cpp",
         "common/extrinsics.cpp",

--- a/src/object-recognition/camera_runner.h
+++ b/src/object-recognition/camera_runner.h
@@ -80,8 +80,6 @@ class CameraRunner {
   std::string GetLastErrorInfo() const;
 
  private:
-  // std::shared_ptr<rs::core::context_interface> ctx_;
-  // rs::device* device_;
   CameraDelegate* ctx_;
   CameraDelegateDevice* device_;
 

--- a/src/object-recognition/camera_runner.h
+++ b/src/object-recognition/camera_runner.h
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "common/camera-options/camera_options_type.h"
+#include "common/camera-delegate/camera_delegate_instance.h"
 
 using namespace rs::core;  // NOLINT(*)
 using namespace rs::object_recognition;  // NOLINT(*)
@@ -79,8 +80,11 @@ class CameraRunner {
   std::string GetLastErrorInfo() const;
 
  private:
-  std::shared_ptr<rs::core::context_interface> ctx_;
-  rs::device* device_;
+  // std::shared_ptr<rs::core::context_interface> ctx_;
+  // rs::device* device_;
+  CameraDelegate* ctx_;
+  CameraDelegateDevice* device_;
+
   rs::core::correlated_sample_set* sample_set_;
   rs::core::image_info color_info_;
 

--- a/src/object-recognition/package.json
+++ b/src/object-recognition/package.json
@@ -2,7 +2,7 @@
   "name": "node-object",
   "version": "0.9.9",
   "description": "Node.js Object Recognition based on Intel® RealSense™ technology",
-  "main": "",
+  "main": "index.js",
   "scripts": {
     "install": "node -e \"require('./common/scripts/build_utils.js').runNodeGyp();\"",
     "maketarball": "bash ./common/scripts/make_tarball.sh node-object",

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "multiple-addon-test",
+  "version": "0.0.1",
+  "description": "Only for test cases",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "assert": "^1.4.1",
+    "bindings": "^1.2.1",
+    "tmp": "0.0.31"
+  }
+}

--- a/src/person-tracking/binding.gyp
+++ b/src/person-tracking/binding.gyp
@@ -61,6 +61,8 @@
       "sources": [
         "addon.cpp",
         "bounding_box2d_info.cpp",
+        "common/camera-delegate/camera_delegate.cpp",
+        "common/camera-delegate/camera_delegate_instance.cpp",
         "common/camera-options/camera_options_host.cpp",
         "common/camera-options/camera_options_host_instance.cpp",
         "common/extrinsics.cpp",

--- a/src/person-tracking/example/pt.js
+++ b/src/person-tracking/example/pt.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-let pt = require('person-tracking');
+let pt = require('..');
 let trackerOptions = {
   skeleton: {
     enable: true,

--- a/src/person-tracking/worker/person_tracker_adapter.h
+++ b/src/person-tracking/worker/person_tracker_adapter.h
@@ -23,6 +23,7 @@
 
 #include "common/camera-options/camera_options_io.h"
 #include "common/frame_data.h"
+#include "common/camera-delegate/camera_delegate_instance.h"
 #include "gen/camera_options.h"
 #include "gen/person_tracker_options.h"
 #include "gen/nan__person_tracking_result.h"
@@ -213,8 +214,8 @@ class PersonTrackerAdapter : public CameraOptionsIO {
   void ResetStateData();
 
   PersonTrackingConfig config_;
-  std::shared_ptr<rs::core::context_interface> ctx_;
-  rs::device* device_;
+  CameraDelegate* ctx_;
+  CameraDelegateDevice* device_;
   std::shared_ptr<rs::person_tracking::person_tracking_video_module_interface> pt_module_; //NOLINT
   rs::core::video_module_interface::actual_module_config actual_module_config_;
   std::mutex result_mutex_;

--- a/src/slam/binding.gyp
+++ b/src/slam/binding.gyp
@@ -43,6 +43,8 @@
         "common/extrinsics.cpp",
         "common/frame_data_assembler.cpp",
         "common/frame_data.cpp",
+        "common/camera-delegate/camera_delegate.cpp",
+        "common/camera-delegate/camera_delegate_instance.cpp",
         "common/camera-options/camera_options_host.cpp",
         "common/camera-options/camera_options_host_instance.cpp",
         "common/geometry/point2d.cpp",

--- a/src/slam/slam_module.h
+++ b/src/slam/slam_module.h
@@ -74,8 +74,6 @@ class SlamModule : public CameraOptionsIO {
   utils::Status SetMotionCallbacks();
 
   // These should only be accessible to worker.
-  // rs::context* rs_context_;
-  // rs::device* device_;
   CameraDelegate* rs_context_;
   CameraDelegateDevice* device_;
   std::shared_ptr<rs::slam::slam> slam_;

--- a/src/slam/slam_module.h
+++ b/src/slam/slam_module.h
@@ -12,6 +12,7 @@
 
 #include "common/camera-options/camera_options_host_instance.h"
 #include "common/camera-options/camera_options_io.h"
+#include "common/camera-delegate/camera_delegate_instance.h"
 #include "gen/camera_options.h"
 #include "gen/instance_options.h"
 #include "parameter_wrappers.h"
@@ -22,13 +23,15 @@
 
 class SlamModule : public CameraOptionsIO {
  public:
-  SlamModule() {
+  SlamModule() : rs_context_(nullptr) {
+    rs_context_ = CameraDelegateInstance::GetInstance();
     CleanUp();
     RegisterToCameraHost();
   }
 
   ~SlamModule() {
-     CleanUp();
+    CleanUp();
+    rs_context_ = nullptr;  // No need to delete singleton object here
   }
 
   utils::Status Start();
@@ -71,8 +74,10 @@ class SlamModule : public CameraOptionsIO {
   utils::Status SetMotionCallbacks();
 
   // These should only be accessible to worker.
-  rs::context rs_context_;
-  rs::device* device_;
+  // rs::context* rs_context_;
+  // rs::device* device_;
+  CameraDelegate* rs_context_;
+  CameraDelegateDevice* device_;
   std::shared_ptr<rs::slam::slam> slam_;
 
   rs::core::video_module_interface::supported_module_config

--- a/src/test/test-pt-or.js
+++ b/src/test/test-pt-or.js
@@ -1,0 +1,141 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+// eslint-disable-next-line
+'use strict';
+
+/* global describe, it */
+const orModule = require('../object-recognition');
+const ptModule = require('../person-tracking');
+
+describe('Multiple node-realsense addons test suite', function() {
+  function runOR(or) {
+    return or.setObjectRecognitionOptions({
+      mode: 'single-recognition',
+      confidenceThreshold: 0.3,
+      computeEngine: 'CPU',
+      enableSegmentation: true,
+      maxReturnObjectCount: 2,
+      enableObjectCenterEstimation: false,
+    }).then(function() {
+      // console.log('run OR');
+      return or.start();
+    });
+  }
+
+  function runPT(pt) {
+    // console.log('run PT');
+    return pt.start();
+  }
+
+  function verifyOR(runNumOfFrames) {
+    return new Promise(function(resolve, reject) {
+      let counter = 0;
+      orModule.createObjectRecognizer().then(function(or) {
+        or.on('recognition', function(eventData) {
+          if (counter >= 0) {
+            ++ counter;
+          }
+
+          if (counter > runNumOfFrames) {
+            counter = -1;
+            // console.log('stopping OR');
+            or.stop().then(function() {
+              // console.log('OR is stopped');
+              resolve('Yes, OR works');
+            }).catch(function(e) {
+              reject(e);
+            });
+          }
+        });
+
+        return runOR(or).catch(function(e) {
+          reject('Failed to run OR');
+        });
+      });
+    });
+  }
+
+  function verifyPT(runNumOfFrames) {
+    return new Promise(function(resolve, reject) {
+      let counter = 0;
+      ptModule.createPersonTracker().then(function(pt) {
+        pt.on('frameprocessed', function(result) {
+          if (counter >= 0) {
+            ++ counter;
+          }
+
+          if (counter > runNumOfFrames) {
+            counter = -1;
+            // console.log('stopping PT');
+            pt.stop().then(function() {
+              // console.log('PT is stopped');
+              resolve('Yes, PT works');
+            }).catch(function(e) {
+              reject(e);
+            });
+          }
+        });
+
+        return runPT(pt).catch(function(e) {
+          reject('Failed to run PT');
+        });
+      });
+    });
+  }
+
+  function delayRunOR(runNumOfFrames, delay) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        verifyOR(runNumOfFrames).then(function(v) {
+          resolve(v);
+        }).catch(function(e) {
+          reject(e);
+        });
+      }, delay);
+    });
+  }
+
+  function delayRunPT(runNumOfFrames, delay) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        verifyPT(runNumOfFrames).then(function(v) {
+          resolve(v);
+        }).catch(function(e) {
+          reject(e);
+        });
+      }, delay);
+    });
+  }
+
+  it('Make sure OR + PT can be run/stop at (almost) the same time', function() {
+    // eslint-disable-next-line
+    this.timeout(15 * 1000);
+    return Promise.all([verifyOR(100), verifyPT(100)]);
+  });
+
+  it('Make sure OR can be still working after PT is stopped', function() {
+    // eslint-disable-next-line
+    this.timeout(15 * 1000);
+    return Promise.all([verifyOR(100), verifyPT(50)]);
+  });
+
+  it('Make sure PT can be still working after OR is stopped', function() {
+    // eslint-disable-next-line
+    this.timeout(15 * 1000);
+    return Promise.all([verifyOR(50), verifyPT(100)]);
+  });
+
+  it('Make sure PT can be started while OR is running', function() {
+    // eslint-disable-next-line
+    this.timeout(30 * 1000);
+    return Promise.all([delayRunOR(240, 0), delayRunPT(120, 5000)]);
+  });
+
+  it('Make sure OR can be started while PT is running', function() {
+    // eslint-disable-next-line
+    this.timeout(30 * 1000);
+    return Promise.all([delayRunOR(120, 5000), delayRunPT(240, 0)]);
+  });
+});


### PR DESCRIPTION
Enable multiple add-on(s) start/stop in arbitrary order in parallel.

There will be some known issues after merging this PR. Will create new issues to track them after the merge.

List of known issues:
 - playback context has to be created every time (even if it's the same cached pointer)
 - in SLAM, camera init is too early, suggest to postpone it, to make user's `CameraOptions` work
 - Shared memory object can't get cleaned up in some exceptions/etc.
 - Expected: more test cases for multiple addon to work together (5 at present)