### PR TITLE
[librealsense]Avoid double freeing

### DIFF
--- a/src/librealsense/frame_data.cpp
+++ b/src/librealsense/frame_data.cpp
@@ -4,7 +4,7 @@
 
 #include "frame_data.h"
 
-FrameData::FrameData() {
+FrameData::FrameData() : own_data_(true) {
   data_.data = nullptr;
 }
 
@@ -14,7 +14,8 @@ FrameData::FrameData(const FrameData& rhs) {
 }
 
 FrameData::~FrameData() {
-  free(data_.data);
+  if (own_data_)
+    free(data_.data);
 }
 
 FrameData& FrameData::operator = (const FrameData& rhs) {

--- a/src/librealsense/frame_data.h
+++ b/src/librealsense/frame_data.h
@@ -29,6 +29,7 @@ class FrameData {
   }
 
   ArrayBuffer get_data() const {
+    own_data_ = false;
     return this->data_;
   }
 
@@ -41,6 +42,8 @@ class FrameData {
   std::string stream_;
 
   ArrayBuffer data_;
+
+  mutable bool own_data_;
 
   friend class DeviceRunner;
 };


### PR DESCRIPTION
We should not free the memory after the ownership has been transferred
to Nan::NewBuffer.

Fix #219