### PR TITLE
[librealsense]Extend lifecycle of rs::context

### DIFF
--- a/src/librealsense/context_runner.cpp
+++ b/src/librealsense/context_runner.cpp
@@ -5,9 +5,11 @@
 #include "context_runner.h"
 
 #include <librealsense/rs.hpp>
+#include <memory>
 
-ContextRunner::ContextRunner()
-  : context_(nullptr) {
+static std::unique_ptr<rs::context> g_context = nullptr;
+
+ContextRunner::ContextRunner() {
 }
 
 ContextRunner::~ContextRunner() {
@@ -22,8 +24,8 @@ rs::device* ContextRunner::GetRSDevice(int index) {
 }
 
 rs::context* ContextRunner::GetRSContext() {
-  if (!context_) {
-    context_.reset(new rs::context());
+  if (!g_context) {
+    g_context.reset(new rs::context());
   }
-  return context_.get();
+  return g_context.get();
 }

--- a/src/librealsense/context_runner.h
+++ b/src/librealsense/context_runner.h
@@ -5,8 +5,6 @@
 #ifndef _CONTEXT_RUNNER_H_
 #define _CONTEXT_RUNNER_H_
 
-#include <memory>
-
 namespace rs {
 class context;
 class device;
@@ -22,9 +20,6 @@ class ContextRunner {
 
  protected:
   rs::context* GetRSContext();
-
- private:
-  std::unique_ptr<rs::context> context_;
 };
 
 #endif  // _CONTEXT_RUNNER_H_

--- a/src/librealsense/examples/get-frame.js
+++ b/src/librealsense/examples/get-frame.js
@@ -40,8 +40,6 @@ context.getDevice(0).then((device) => {
       console.log(e);
     });
   });
-
-  device.context = context;
 }).catch((e) => {
   console.log(e);
 });


### PR DESCRIPTION
The created Context object will be recycled by the GC if we don't hold a
reference, which will lead the rs::context and its related rs::device
are going to be de-constructed. So, here we'd better extend the life
cycle of rs::context to the whole process by using a static global
variable.

Fix #222