### PR TITLE
[librealsense]Implement more interfaces

### DIFF
--- a/src/librealsense/addon.cpp
+++ b/src/librealsense/addon.cpp
@@ -5,11 +5,13 @@
 #include "gen/nan__context.h"
 #include "gen/nan__device.h"
 #include "gen/nan__frame_data.h"
+#include "gen/nan__rs_extrinsics.h"
 
 void initModule(v8::Local<v8::Object> exports) {
   NanContext::Init(exports);
   NanDevice::Init(exports);
   NanFrameData::Init(exports);
+  NanRSExtrinsics::Init(exports);
 }
 
 NODE_MODULE(node_librealsense, initModule);

--- a/src/librealsense/apis.md
+++ b/src/librealsense/apis.md
@@ -23,13 +23,13 @@ getFrameTimeStamp | √ | retrieve the time at which the frame was captured
 start | √ | begin streaming on all enabled streams for this device
 stop | √ | end streaming on all streams for this device
 getFrameData | √ (supported by event) | retrieve the contents of the latest frame on a stream
-getUSBPortId | x | retrieve the USB port number
-getInfo | x | retrieve camera specific information like the versions of the various componnents
-getExtrinsics | x | retrieve extrinsic transformation between the viewpoints of two different streams
-getMotionExtrinsicsFrom | x | retrieve extrinsic transformation between the viewpoints of specific stream and the motion module
-disableStream | x | disable a specific stream
-getStreamFormat | x | retrieve the pixel format for a specific stream
-getStreamFramerate | x | retrieve the framerate for a specific stream
+getUSBPortId | √ | retrieve the USB port number
+getInfo | √ | retrieve camera specific information like the versions of the various componnents
+getExtrinsics | √ | retrieve extrinsic transformation between the viewpoints of two different streams
+getMotionExtrinsicsFrom | √ | retrieve extrinsic transformation between the viewpoints of specific stream and the motion module
+disableStream | √ | disable a specific stream
+getStreamFormat | √ | retrieve the pixel format for a specific stream
+getStreamFramerate | √ | retrieve the framerate for a specific stream
 getStreamIntrinsics | x | retrieve intrinsic camera parameters for a specific stream
 getMotionIntrinsics | x | retrieve intrinsic camera parameters for the motion module
 getOptionRange | x | retrieve the available range of values of a supported option
@@ -37,7 +37,7 @@ getOption(s) | x | retrieve the value of an arbitrary number of options
 setOptions(s) | x | set the value of an arbitrary number of options
 getOptionDescription | x | retrieve the device specific option description
 supports | x | determine device capabilities
-getFrameNumber | x | retrieve the time at which the latest frame on a stream was captured
+getFrameNumber | √ | retrieve the time at which the latest frame on a stream was captured
 sendBlobToDevice | x |send device specific data to the device
 enableMotionTracking | x | enable motion module event
 disableMotionTracking | x | disable motion module event

--- a/src/librealsense/binding.gyp
+++ b/src/librealsense/binding.gyp
@@ -11,6 +11,7 @@
           "<(INTERMEDIATE_DIR)/gen/nan__context.cpp",
           "<(INTERMEDIATE_DIR)/gen/nan__device.cpp",
           "<(INTERMEDIATE_DIR)/gen/nan__frame_data.cpp",
+          "<(INTERMEDIATE_DIR)/gen/nan__rs_extrinsics.cpp",
           "<(INTERMEDIATE_DIR)/gen/thread-event-helper.cpp",
         ],
         "widl_files": [
@@ -22,6 +23,7 @@
       ],
       "sources": [
         "addon.cpp",
+        "common/extrinsics.cpp",
         "common/task/async_task.cpp",
         "common/task/async_task_runner.cpp",
         "common/task/async_task_runner_instance.cpp",
@@ -30,6 +32,7 @@
         "device.cpp",
         "device_runner.cpp",
         "frame_data.cpp",
+        "rs_extrinsics.cpp",
         "rs_task.cpp",
         "utils.cpp",
       ],

--- a/src/librealsense/device.cpp
+++ b/src/librealsense/device.cpp
@@ -104,6 +104,48 @@ v8::Handle<v8::Promise> Device::getFrameTimeStamp(const std::string& stream) {
       {{GET_FRAME_TIMESTAMP MESSAGE}}, stream);
 }
 
+v8::Handle<v8::Promise> Device::getUSBPortId() {
+  POST_DEVICE_PROMISE_TASK(std::string, GetUSBPortId,
+      {{GET_USB_PORT_ID MESSAGE}});
+}
+
+v8::Handle<v8::Promise> Device::getInfo(const std::string& info) {
+  POST_DEVICE_PROMISE_TASK(std::string, GetInfo,
+      {{GET_INFO MESSAGE}}, info);
+}
+
+v8::Handle<v8::Promise> Device::getExtrinsics(const std::string& from,
+                                      const std::string& to) {
+  POST_DEVICE_PROMISE_TASK(RSExtrinsics*, GetExtrinsics,
+      {{GET_EXTRINSICS MESSAGE}}, from, to);
+}
+
+v8::Handle<v8::Promise> Device::getMotionExtrinsicsFrom(
+    const std::string& from) {
+  POST_DEVICE_PROMISE_TASK(RSExtrinsics*, GetMotionExtrinsicsFrom,
+      {{GET_MOTION_EXTRINSICS MESSAGE}}, from);
+}
+
+v8::Handle<v8::Promise> Device::disableStream(const std::string& stream) {
+  POST_DEVICE_PROMISE_TASK(void, DisableStream, {{DISABLE_STREAM MESSAGE}},
+    stream);
+}
+
+v8::Handle<v8::Promise> Device::getStreamFormat(const std::string& stream) {
+  POST_DEVICE_PROMISE_TASK(std::string, GetStreamFormat,
+      {{GET_STREAM_FORMAT MESSAGE}}, stream);
+}
+
+v8::Handle<v8::Promise> Device::getStreamFramerate(const std::string& stream) {
+  POST_DEVICE_PROMISE_TASK(int, GetStreamFramerate,
+      {{GET_STREAM_FRAMERATE MESSAGE}}, stream);
+}
+
+v8::Handle<v8::Promise> Device::getFrameNumber(const std::string& stream) {
+    POST_DEVICE_PROMISE_TASK(int, GetFrameNumber,
+      {{GET_FRAME_NUMBER MESSAGE}}, stream);
+}
+
 v8::Handle<v8::Promise> Device::start() {
   POST_DEVICE_PROMISE_TASK(void, Start, {{START_DEVICE MESSAGE}});
 }

--- a/src/librealsense/device.h
+++ b/src/librealsense/device.h
@@ -56,6 +56,23 @@ class Device {
 
   v8::Handle<v8::Promise> getFrameTimeStamp(const std::string& stream);
 
+  v8::Handle<v8::Promise> getUSBPortId();
+
+  v8::Handle<v8::Promise> getInfo(const std::string& info);
+
+  v8::Handle<v8::Promise> getExtrinsics(const std::string& from,
+                                        const std::string& to);
+
+  v8::Handle<v8::Promise> getMotionExtrinsicsFrom(const std::string& from);
+
+  v8::Handle<v8::Promise> disableStream(const std::string& stream);
+
+  v8::Handle<v8::Promise> getStreamFormat(const std::string& stream);
+
+  v8::Handle<v8::Promise> getStreamFramerate(const std::string& stream);
+
+  v8::Handle<v8::Promise> getFrameNumber(const std::string& stream);
+
   v8::Handle<v8::Promise> start();
 
   v8::Handle<v8::Promise> stop();

--- a/src/librealsense/device_runner.cpp
+++ b/src/librealsense/device_runner.cpp
@@ -8,6 +8,7 @@
 
 #include "common/task/async_task_runner_instance.h"
 #include "gen/nan__frame_data.h"
+#include "rs_extrinsics.h"
 #include "rs_payload.h"
 #include "rs_task.h"
 #include "utils.h"
@@ -105,6 +106,61 @@ DictionaryMode DeviceRunner::GetStreamMode(const std::string& stream,
   mode.member_framerate = framerate;
 
   return mode;
+}
+
+std::string DeviceRunner::GetUSBPortId() {
+  return device_->get_usb_port_id();
+}
+
+std::string DeviceRunner::GetInfo(const std::string& info) {
+  rs::camera_info rs_camera_info = GetCameraInfoFromString(info);
+  return device_->get_info(rs_camera_info);
+}
+
+RSExtrinsics* DeviceRunner::GetExtrinsics(const std::string& from,
+                                       const std::string& to) {
+  rs::stream from_stream = GetRSStreamFromString(from);
+  rs::stream to_stream = GetRSStreamFromString(to);
+  rs::extrinsics rs_extrinsics =
+      device_->get_extrinsics(from_stream, to_stream);
+
+  return new RSExtrinsics(rs_extrinsics);
+}
+
+RSExtrinsics* DeviceRunner::GetMotionExtrinsicsFrom(const std::string& from) {
+  rs::stream from_stream = GetRSStreamFromString(from);
+  rs::extrinsics rs_extrinsics =
+    device_->get_motion_extrinsics_from(from_stream);
+
+  return new RSExtrinsics(rs_extrinsics);
+}
+
+void DeviceRunner::DisableStream(const std::string& stream) {
+  rs::stream rs_stream = GetRSStreamFromString(stream);
+  std::vector<rs::stream>::iterator it =
+      std::find(enabled_streams_vector_.begin(),
+                enabled_streams_vector_.end(),
+                rs_stream);
+
+  if (it != enabled_streams_vector_.end()) {
+    device_->disable_stream(rs_stream);
+    enabled_streams_vector_.erase(it);
+  }
+}
+
+std::string DeviceRunner::GetStreamFormat(const std::string& stream) {
+  rs::stream rs_stream = GetRSStreamFromString(stream);
+  return GetStringFromRSFormat(device_->get_stream_format(rs_stream));
+}
+
+int DeviceRunner::GetStreamFramerate(const std::string& stream) {
+  rs::stream rs_stream = GetRSStreamFromString(stream);
+  return device_->get_stream_framerate(rs_stream);
+}
+
+int DeviceRunner::GetFrameNumber(const std::string& stream) {
+  rs::stream rs_stream = GetRSStreamFromString(stream);
+  return device_->get_frame_number(rs_stream);
 }
 
 void DeviceRunner::GetFrameDataFromRSFrame(rs::frame frame) {

--- a/src/librealsense/device_runner.h
+++ b/src/librealsense/device_runner.h
@@ -11,10 +11,13 @@
 
 #include "frame_data.h"
 #include "gen/mode.h"
+#include "rs_extrinsics.h"
 
 namespace rs {
 class device;
 }  // namespace rs
+
+class RSExtrinsics;
 
 class DeviceRunner {
  public:
@@ -37,6 +40,15 @@ class DeviceRunner {
   int GetFrameTimeStamp(const std::string& stream);
 
   void GetFrameDataFromRSFrame(rs::frame frame);
+  std::string GetUSBPortId();
+  std::string GetInfo(const std::string& info);
+  RSExtrinsics* GetExtrinsics(const std::string& from, const std::string& to);
+  RSExtrinsics* GetMotionExtrinsicsFrom(const std::string& from);
+  void DisableStream(const std::string& stream);
+  std::string GetStreamFormat(const std::string& stream);
+  int GetStreamFramerate(const std::string& stream);
+  int GetFrameNumber(const std::string& stream);
+
   void Start();
   void Stop();
 

--- a/src/librealsense/idl/node-librealsense.widl
+++ b/src/librealsense/idl/node-librealsense.widl
@@ -96,6 +96,44 @@ enum OptionType {
   "r200_depth_control_lr_threshold"
 };
 
+enum CameraInfo {
+  "device_name",
+  "serial_number",
+  "camera_firmware_version",
+  "adapter_board_firmware_version",
+  "motion_module_firmware_version",
+  "camera_type",
+  "oem_id",
+  "isp_fw_version",
+  "content_version",
+  "module_version",
+  "imager_model_number",
+  "build_date",
+  "calibration_date",
+  "program_date",
+  "focus_alignment_date",
+  "emitter_type",
+  "focus_value",
+  "lens_type",
+  "third_lens_type",
+  "lens_coating_type",
+  "third_lens_coating_type",
+  "lens_nominal_baseline",
+  "third_lens_nominal_baseline"
+};
+
+enum Capabilities {
+  "depth",
+  "color",
+  "infrared",
+  "infrared2",
+  "fish_eye",
+  "motion_events",
+  "motion_module_fw_update",
+  "adapter_board",
+  "enumeration"
+};
+
 dictionary Mode {
   long width;
   long height;
@@ -132,6 +170,14 @@ interface Device {
   Promise<long> getStreamWidth(StreamType stream);
   Promise<long> getStreamHeight(StreamType stream);
   Promise<long> getFrameTimeStamp(StreamType stream);
+  Promise<String> getUSBPortId();
+  Promise<String> getInfo(CameraInfo info);
+  Promise<RSExtrinsics> getExtrinsics(StreamType from, StreamType to);
+  Promise<RSExtrinsics> getMotionExtrinsicsFrom(StreamType from);
+  Promise<void> disableStream(StreamType stream);
+  Promise<FormatType> getStreamFormat(StreamType stream);
+  Promise<long> getStreamFramerate(StreamType stream);
+  Promise<long> getFrameNumber(StreamType stream);
 
   Promise<void> start();
   Promise<void> stop();
@@ -140,4 +186,11 @@ interface Device {
 interface FrameData {
   readonly attribute StreamType stream;
   readonly attribute ArrayBuffer data;
+};
+
+interface RSExtrinsics {
+  readonly attribute boolean isIdentity;
+  readonly attribute Float32Array rotation;
+  readonly attribute Float32Array translation;
+  Float32Array transform(Float32Array point);
 };

--- a/src/librealsense/rs_extrinsics.cpp
+++ b/src/librealsense/rs_extrinsics.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#include "rs_extrinsics.h"
+
+RSExtrinsics::RSExtrinsics(rs::extrinsics extrinsics)
+    : Extrinsics(extrinsics.rotation, extrinsics.translation),
+      extrinsics_(extrinsics),
+      isIdentity_(extrinsics.is_identity()) {
+  SetupTypedArrayHelper(&transform_, transform_store_, TRANSLATION_SIZE);
+}
+
+Float32ArrayHelper RSExtrinsics::transform(
+    const Float32ArrayHelper& point) {
+  DeepCopyFromTypedArrayHelper(point, transform_store_, TRANSLATION_SIZE);
+  rs::float3 transform;
+  transform.x = transform_store_[0];
+  transform.y = transform_store_[1];
+  transform.z = transform_store_[2];
+
+  transform = extrinsics_.transform(transform);
+
+  transform_store_[0] = transform.x;
+  transform_store_[1] = transform.y;
+  transform_store_[2] = transform.z;
+
+  return transform_;
+}
+
+  RSExtrinsics& RSExtrinsics::operator = (const RSExtrinsics& rhs) {
+    if (this != &rhs) {
+      extrinsics_ = rhs.extrinsics_;
+      isIdentity_ = rhs.isIdentity_;
+
+      for (uint i = 0; i < TRANSLATION_SIZE; i++) {
+        transform_store_[i] = rhs.transform_store_[i];
+      }
+    }
+    return *this;
+  }

--- a/src/librealsense/rs_extrinsics.h
+++ b/src/librealsense/rs_extrinsics.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+#ifndef _RS_EXTRINSICS_H_
+#define _RS_EXTRINSICS_H_
+
+#include <librealsense/rs.hpp>
+#include <node.h>
+#include <v8.h>
+
+#include <string>
+
+#include "common/extrinsics.h"
+#include "gen/generator_helper.h"
+#include "gen/array_helper.h"
+
+class RSExtrinsics : public Extrinsics {
+ public:
+  RSExtrinsics() {}
+
+  explicit RSExtrinsics(const RSExtrinsics& rhs) = delete;
+
+  explicit RSExtrinsics(rs::extrinsics extrinsics);
+
+  RSExtrinsics& operator = (const RSExtrinsics& rhs);
+
+ public:
+  bool get_isIdentity() const {
+    return this->isIdentity_;
+  }
+
+  Float32ArrayHelper transform(const Float32ArrayHelper& point);  // NOLINT
+
+  void SetJavaScriptThis(v8::Local<v8::Object> obj) {
+    // Ignore this if you don't need it
+    // Typical usage: emit an event on `obj`
+  }
+
+ private:
+  rs::extrinsics extrinsics_;
+
+  bool isIdentity_;
+
+  Float32ArrayHelper transform_;
+  float transform_store_[TRANSLATION_SIZE];
+};
+
+#endif  // _RS_EXTRINSICS_H_

--- a/src/librealsense/rs_task.cpp
+++ b/src/librealsense/rs_task.cpp
@@ -7,6 +7,7 @@
 #include "device.h"
 #include "device_runner.h"
 #include "gen/nan__device.h"
+#include "gen/nan__rs_extrinsics.h"
 
 bool RSFrameReadyEventTask::ShouldPopEvent(size_t event_index) {
   const char* api_name_string = "listenerCount";
@@ -70,4 +71,9 @@ v8::Local<v8::Value> RSPromiseTask<rs::device*>::GetResolved() {
   device->SetDeviceRunner(new DeviceRunner(GetPayload()->GetPayloadData()));
   return static_cast<v8::Local<v8::Object>>(
       NanDevice::NewInstance(device));
+}
+
+template<>
+v8::Local<v8::Value> RSPromiseTask<RSExtrinsics*>::GetResolved() {
+  return NanRSExtrinsics::NewInstance(GetPayload()->GetPayloadData());
 }

--- a/src/librealsense/rs_task.h
+++ b/src/librealsense/rs_task.h
@@ -9,10 +9,13 @@
 #include <string>
 
 #include "common/task/async_task.h"
+#include "extrinsics.h"
 #include "frame_data.h"
 #include "gen/mode.h"
 #include "gen/nan__frame_data.h"
 #include "rs_payload.h"
+
+class RSExtrinsics;
 
 class RSFrameReadyEventTask : public DirectEventEmitterTask {
  public:
@@ -100,4 +103,6 @@ v8::Local<v8::Value> RSPromiseTask<void>::GetResolved();
 template<>
 v8::Local<v8::Value> RSPromiseTask<rs::device*>::GetResolved();
 
+template<>
+v8::Local<v8::Value> RSPromiseTask<RSExtrinsics*>::GetResolved();
 #endif  // _RS_TASK_H_

--- a/src/librealsense/test/test-device.js
+++ b/src/librealsense/test/test-device.js
@@ -97,7 +97,7 @@ describe('Test Device interfaces', function() {
     });
   });
 
-  it('Enable stream', function() {
+  it('Enable/Disable stream', function() {
     return new Promise((resolve, reject) => {
       let mode = {
         width: 640,
@@ -108,8 +108,8 @@ describe('Test Device interfaces', function() {
 
       device.enableStream('color', mode).then(() => {
         device.isStreamEnabled('color').then((enable) => {
-            assert.equal(typeof enable, 'boolean');
-            console.log('The color stream has been enabled.');
+          assert.equal(typeof enable, 'boolean');
+          console.log('The color stream has been enabled.');
           resolve();
         });
       }).catch((e) => {
@@ -204,6 +204,101 @@ describe('Test Device interfaces', function() {
         }).catch((e) => {
           reject(e);
         });
+      });
+    });
+  });
+
+  it('Get USB port Id', function() {
+    return new Promise((resolve, reject) => {
+      device.getUSBPortId().then((portId)=> {
+        console.log('The USB port Id is ' + portId);
+        resolve();
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  });
+
+  it('Get Camera Info', function() {
+    return new Promise((resolve, reject) => {
+      device.getInfo('device_name').then((info) => {
+        console.log('Camera info of device name is ' + info);
+        resolve();
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  });
+
+  it('Get extrinsics', function() {
+    return new Promise((resolve, reject) => {
+      device.getExtrinsics('color', 'depth').then((extrinsics) => {
+        console.log('rotation value is ' + extrinsics.rotation);
+        console.log('translation value is ' + extrinsics.translation);
+        console.log('identity is ' + extrinsics.isIdentity);
+        console.log('transform point (1, 1, 1) to ' +
+            extrinsics.transform(new Float32Array([1, 1, 1])));
+        resolve();
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  });
+
+  it('Get stream format', function() {
+    return new Promise((resolve, reject) => {
+      device.getStreamFormat('color').then((format) => {
+        console.log('The color stream format is ' + format);
+        resolve();
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  });
+
+  it('Get stream framerate', function() {
+    return new Promise((resolve, reject) => {
+      device.getStreamFramerate('color').then((framerate) => {
+        console.log('The color stream framerate is ' + framerate);
+        resolve();
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  });
+
+  it('Get frame number', function() {
+    return new Promise((resolve, reject) => {
+      device.getFrameNumber('color').then((number) => {
+        console.log('The frame number is ' + number);
+        resolve();
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  });
+
+  it('Disable stream', function() {
+    return new Promise((resolve, reject) => {
+      device.disableStream('color').then(() => {
+        resolve();
+      }).catch((e) => {
+        reject(e);
+      });
+    });
+  });
+
+  it('Get motion extrinsics', function() {
+    return new Promise((resolve, reject) => {
+      device.getMotionExtrinsicsFrom('depth').then((extrinsics) => {
+        console.log('rotation value is ' + extrinsics.rotation);
+        console.log('translation value is ' + extrinsics.translation);
+        console.log('identity is ' + extrinsics.isIdentity);
+        console.log('transform point (1, 1, 1) to ' +
+            extrinsics.transform(new Float32Array([1, 1, 1])));
+        resolve();
+      }).catch((e) => {
+        reject(e);
       });
     });
   });

--- a/src/librealsense/utils.cpp
+++ b/src/librealsense/utils.cpp
@@ -235,3 +235,54 @@ rs::format GetRSFormatFromString(const std::string& format) {
   else
     return rs::format::any;
 }
+
+rs::camera_info GetCameraInfoFromString(const std::string& info) {
+  if (info == "device_name")
+    return rs::camera_info::device_name;
+  else if (info == "serial_number")
+    return rs::camera_info::serial_number;
+  else if (info == "camera_firmware_version")
+    return rs::camera_info::camera_firmware_version;
+  else if (info == "adapter_board_firmware_version")
+    return rs::camera_info::adapter_board_firmware_version;
+  else if (info == "motion_module_firmware_version")
+    return rs::camera_info::motion_module_firmware_version;
+  else if (info == "camera_type")
+    return rs::camera_info::camera_type;
+  else if (info == "oem_id")
+    return rs::camera_info::oem_id;
+  else if (info == "isp_fw_version")
+    return rs::camera_info::isp_fw_version;
+  else if (info == "content_version")
+    return rs::camera_info::content_version;
+  else if (info == "module_version")
+    return rs::camera_info::module_version;
+  else if (info == "imager_model_number")
+    return rs::camera_info::imager_model_number;
+  else if (info == "build_date")
+    return rs::camera_info::build_date;
+  else if (info == "calibration_date")
+    return rs::camera_info::calibration_date;
+  else if (info == "program_date")
+    return rs::camera_info::program_date;
+  else if (info == "focus_alignment_date")
+    return rs::camera_info::focus_alignment_date;
+  else if (info == "emitter_type")
+    return rs::camera_info::emitter_type;
+  else if (info == "focus_value")
+    return rs::camera_info::focus_value;
+  else if (info == "lens_type")
+    return rs::camera_info::lens_type;
+  else if (info == "third_lens_type")
+    return rs::camera_info::third_lens_type;
+  else if (info == "lens_coating_type")
+    return rs::camera_info::lens_coating_type;
+  else if (info == "third_lens_coating_type")
+    return rs::camera_info::third_lens_coating_type;
+  else if (info == "lens_nominal_baseline")
+    return rs::camera_info::lens_nominal_baseline;
+  else if (info == "third_lens_nominal_baseline")
+    return rs::camera_info::third_lens_nominal_baseline;
+  else
+    return rs::camera_info::device_name;
+}

--- a/src/librealsense/utils.h
+++ b/src/librealsense/utils.h
@@ -16,6 +16,8 @@ rs::option GetRSOptionFromString(const std::string& option);
 
 std::string GetStringFromRSFormat(const rs::format format);
 
+rs::camera_info GetCameraInfoFromString(const std::string& info);
+
 rs::format GetRSFormatFromString(const std::string& format);
 
 #endif  // _UTILS_H


### PR DESCRIPTION
This patch implements the following interfaces compared with native
librealsense:
*getUSBPortId
*getInfo
*getExtrinsics
*getMotionExtrinsicsFrom
*disableStream
*getStreamFormat
*getStreamFramerate
*getFrameNumber

See the details at apis.md.